### PR TITLE
Fixing travis-ci badge.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,8 +6,8 @@ git_wrapper
 .. image:: https://img.shields.io/pypi/v/git_wrapper.svg
         :target: https://pypi.python.org/pypi/git_wrapper
 
-.. image:: https://img.shields.io/travis/fuzzball81/git_wrapper.svg
-        :target: https://travis-ci.org/fuzzball81/git_wrapper
+.. image:: https://img.shields.io/travis/release-depot/git_wrapper.svg
+        :target: https://travis-ci.org/release-depot/git_wrapper
 
 .. image:: https://readthedocs.org/projects/git-wrapper/badge/?version=latest
         :target: https://git-wrapper.readthedocs.io/en/latest/?badge=latest


### PR DESCRIPTION
Fixing the travis-ci badge to look at release-depot instead of a fork.

Signed-off-by: Jason Joyce <fuzzball81@gmail.com>