### PR TITLE
'Make lint' should match the tox setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ clean-test: ## remove test and coverage artifacts
 	rm -fr htmlcov/
 
 lint: ## check style with flake8
-	pipenv run flake8 git_wrapper tests
+	pipenv run flake8 --ignore=E501 git_wrapper tests
 
 test: dev ## run tests quickly with the default Python
 	pipenv run py.test tests


### PR DESCRIPTION
Currently, 'make lint' fails because it's lacking the same 'ignore' rules set up in the tox flake8 job.