### PR TITLE
Fixing tox.ini flake8 for tests.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,4 +20,4 @@ passenv=HOME
 deps = flake8
 sitepackages = False
 commands =
-    flake8 --ignore=E501 setup.py docs git_wrapper test
+    flake8 --ignore=E501 setup.py docs git_wrapper tests


### PR DESCRIPTION
The tox.ini has 'test' instead of 'tests'.

Fixes #7 