### PR TITLE
Removing python 2 support.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,12 @@ Features
 
 * TODO
 
+Notes
+-----
+
+This library only supports python 3. Some features may still work with python 2.7 but not all of the
+syntax and features my be compatible.
+
 Development
 -----------
 

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,6 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
-        "Programming Language :: Python :: 2",
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,11 @@
 [tox]
-envlist = py27, py34, py35, py36, flake8
+envlist = py34, py35, py36, flake8
 
 [travis]
 python =
     3.6: py36
     3.5: py35
     3.4: py34
-    2.7: py27
 
 [testenv]
 passenv=HOME


### PR DESCRIPTION
Python 3 is the new standard and it makes sense to target that version
with this new library.

Signed-off-by: Jason Joyce <fuzzball81@gmail.com>