### PR TITLE
Fixing readthedocs not generating api information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,9 +65,9 @@ coverage: ## check code coverage quickly with the default Python
 	$(BROWSER) htmlcov/index.html
 
 docs: ## generate Sphinx HTML documentation, including API docs
-	rm -f docs/git_wrapper.rst
-	rm -f docs/modules.rst
-	pipenv run sphinx-apidoc -o docs/ git_wrapper
+	rm -f docs/source/git_wrapper.rst
+	rm -f docs/source/modules.rst
+	sphinx-apidoc -o docs/source git_wrapper
 	$(MAKE) -C docs clean
 	$(MAKE) -C docs html
 	$(BROWSER) docs/_build/html/index.html

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,3 +1,1 @@
-/git_wrapper.rst
-/git_wrapper.*.rst
-/modules.rst
+source/*

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line.
 SPHINXOPTS    =
-SPHINXBUILD   = pipenv run python -msphinx
+SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = git_wrapper
 SOURCEDIR     = .
 BUILDDIR      = _build

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,6 +26,22 @@ import git_wrapper
 
 # -- General configuration ---------------------------------------------
 
+# The following is from http://ggeditor.readthedocs.io/en/latest/ApiDoc.html
+def run_apidoc(_):
+    from sphinx.apidoc import main
+    parentFolder = os.path.join(os.path.dirname(__file__), '..')
+    cur_dir = os.path.abspath(os.path.dirname(__file__))
+    sys.path.append(parentFolder)
+    module = os.path.join(parentFolder, 'git_wrapper')
+    output_path = os.path.join(cur_dir, 'source')
+    main(['-e', '-f', '-o', output_path, module])
+
+
+def setup(app):
+    # trigger the run_apidoc
+    app.connect('builder-inited', run_apidoc)
+
+
 # If your documentation needs a minimal Sphinx version, state it here.
 #
 # needs_sphinx = '1.0'
@@ -84,7 +100,7 @@ todo_include_todos = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a
 # theme further.  For a list of options available for each theme, see the

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
 Welcome to git_wrapper's documentation!
-======================================
+=======================================
 
 .. toctree::
    :maxdepth: 2
@@ -8,7 +8,7 @@ Welcome to git_wrapper's documentation!
    readme
    installation
    usage
-   modules
+   source/modules
    contributing
    authors
    history


### PR DESCRIPTION
- Adding a custom function to make readthedocs run
  `sphinx-apidoc` on every run to ensure the apis are up to date.

- Modified the index.rst to look for a source/modules.rst file that will
  be generated from sphinx-apidoc

- Modified the docs/..gitignore file to ignore a locally generated
  source directory.

- Modified several Makefiles to remove references to pipenv.

Signed-off-by: Jason Joyce <fuzzball81@gmail.com>