### PR TITLE
Fix formatting for doc strings

### DIFF
--- a/git_wrapper/base.py
+++ b/git_wrapper/base.py
@@ -9,6 +9,7 @@ class GitWrapperBase(object):
 
     def __init__(self, path='', repo=None):
         """Constructor for GitUtilBase object
+
             :param str path: Path to a git repo Default('')
             :param git.Repo repo: An already constructed git.Repo object to use Default(None)
         """
@@ -17,6 +18,7 @@ class GitWrapperBase(object):
 
     def __setup(self, path, repo):
         """Sets the path and repo after performing validation
+
             :param str path: Path to a directory containing a git repository
             :param git.Repo repo: An already constructed git.Repo object to use
         """
@@ -30,32 +32,36 @@ class GitWrapperBase(object):
     @property
     def repo(self):
         """Returns the git repo for a given path
-            :return A reference to the internal git.Repo object
+
+            :return git.Repo: A reference to the internal git.Repo object
         """
         return self.__repo
 
     @repo.setter
     def repo(self, new_repo):
         """Allows for use of an already constructed repo
+
             :param git.Repo new_repo: An already constructed git.Repo object to use
         """
         self.__repo = new_repo
 
     @property
     def git(self):
-        '''Returns the git command for a given repo'''
+        """Returns the git command for a given repo"""
         return self.repo.git
 
     def remote_names(self):
         """Returns a list of remotes for a given repo
-            :return A list of utf-8 encoded remote names
+
+            :return list: A list of utf-8 encoded remote names
         """
         return [x.name for x in self.repo.remotes]
 
     def describe(self, sha):
         """Return tag and commit info for a given sha
-            :param str sha: The SHA1 of the commit to describe
-            :return dict with tag and patch data
+
+           :param str sha: The SHA1 of the commit to describe
+           :return dict: A dict with tag and patch data
         """
         ret_data = {'tag': '', 'patch': ''}
         output = self.git.describe(sha).split('-g')
@@ -67,6 +73,7 @@ class GitWrapperBase(object):
 
     def add_remote(self, name, url):
         """Adds a remote to the given repo
+
             :param str name: The name for the remote
             :param str url: The url to use for the remote
             :return bool: True if the remote was add, False otherwise

--- a/git_wrapper/rebase.py
+++ b/git_wrapper/rebase.py
@@ -1,4 +1,5 @@
 #! /usr/bin/env python
+"""This module acts as an interface for common git tasks"""
 
 import logging
 
@@ -19,6 +20,7 @@ class GitWrapperRebase(GitWrapperBase):
 
     def to_hash(self, branch_name, hash_):
         """Perform a rebase from a specific reference to another.
+
            :param str branch_name: The name of the branch or reference to start from
            :param str hash_: The commit hash or reference to rebase to
         """

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -11,7 +11,7 @@ from git_wrapper.base import GitWrapperBase
 
 
 def remote_generator(names):
-    '''Generates objects to be used with git.Repo.remotes call'''
+    """Generates objects to be used with git.Repo.remotes call"""
     ret_data = []
     for name in names:
         obj = type('', (), {})()


### PR DESCRIPTION
A function's description needs a blank line before listing the
parameters, or the line breaks won't be displayed in the module
content's documentation.

Also fix up a couple of inconsistent quote marks (''' vs """) that were
missed in PR#16.