### PR TITLE
Import 'mock' from the unittest library

### DIFF
--- a/tests/test_rebase.py
+++ b/tests/test_rebase.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-from unittest.mock import patch
+from mock import patch
 
 import git
 import pytest


### PR DESCRIPTION
This stops the 'make' commands related to testing/coverage and direct calls to py.test (as we document them in the CONTRIBUTING.rst file) from failing.