### PR TITLE
Fix rebasing on branch issue

### DIFF
--- a/git_wrapper/rebase.py
+++ b/git_wrapper/rebase.py
@@ -21,7 +21,7 @@ class GitWrapperRebase(GitWrapperBase):
     def to_hash(self, branch_name, hash_):
         """Perform a rebase from a specific reference to another.
 
-           :param str branch_name: The name of the branch or reference to start from
+           :param str branch_name: The name of the branch to rebase on
            :param str hash_: The commit hash or reference to rebase to
         """
         logger.debug("Rebasing branch %s to hash %s. Repo currently at commit %s.", branch_name, hash_, self.repo.head.commit)
@@ -32,33 +32,33 @@ class GitWrapperRebase(GitWrapperBase):
 
         # Does the branch exist?
         try:
-            branch = git.repo.fun.name_to_object(self.repo, branch_name)
+            git.repo.fun.name_to_object(self.repo, branch_name)
         except git.exc.BadName as ex:
             msg = "Could not find branch %s." % branch_name
             raise exceptions.ReferenceNotFoundException(msg) from ex
 
         # Does the hash exists?
         try:
-            commit = git.repo.fun.name_to_object(self.repo, hash_)
+            git.repo.fun.name_to_object(self.repo, hash_)
         except git.exc.BadName as ex:
             msg = "Could not find hash %s." % hash_
             raise exceptions.ReferenceNotFoundException(msg) from ex
 
         # Checkout
         try:
-            self.repo.git.checkout(branch.hexsha)
+            self.repo.git.checkout(branch_name)
         except git.GitCommandError as ex:
             msg = "Could not checkout branch %s. Error: %s" % (branch_name, ex)
             raise exceptions.CheckoutException(msg) from ex
 
         # Rebase
         try:
-            self.repo.git.rebase(commit.hexsha)
+            self.repo.git.rebase(hash_)
         except git.GitCommandError as ex:
             msg = "Could not rebase hash %s onto branch %s. Error: %s" % (hash_, branch_name, ex)
             raise exceptions.RebaseException(msg) from ex
 
-        logger.debug("Successfully rebased branch %s (%s) to %s" % (branch_name, branch.hexsha, hash_))
+        logger.debug("Successfully rebased branch %s to %s" % (branch_name, hash_))
 
     def abort(self):
         """Abort a rebase."""


### PR DESCRIPTION
Rebase currently creates a 'floating' commit as a result, as opposed to
rebasing the branch itself. This fixes it so that the branch gets
properly updated with the rebase result after running the command.