### PR TITLE
Add Tox & Travis support for py37

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,10 @@ install: pip install -U tox-travis
 
 matrix:
   include:
+    - python: 3.7
+      dist: xenial
     - python: 3.6
       env: TOXENV=flake8
 
 # Command to run tests, e.g. python setup.py test
 script: tox
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ classifiers =
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
 keywords =
     git_wrapper
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
-envlist = py27, py35, py36, flake8
+envlist = py27, py35, py36, py37, flake8
 
 [travis]
 python =
+    3.7: py37
     3.6: py36
     3.5: py35
     2.7: py27


### PR DESCRIPTION
Python 3.7 appears to be a version update that broke the most things in a while, might as well be prepared for the damage.

Travis doesn't currently support it out of the box (cf. https://github.com/travis-ci/travis-ci/issues/9815 ) so it needs to be included in the matrix rather than simply added to the Python list.