### PR TITLE
Removing python 3.5 tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ sudo: required
 language: python
 python:
   - 3.6
-  - 3.5
   - 2.7
 
 services:

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 [tox]
-envlist = py27, py35, py36, py37, flake8
+envlist = py27, py36, py37, flake8
 
 [travis]
 python =
     3.7: py37
     3.6: py36
-    3.5: py35
     2.7: py27
 
 [testenv]


### PR DESCRIPTION
Python 3.6 seems to be what most distros are moving toward. Dropping the
python 3.5 setup in tox.

Signed-off-by: Jason Joyce <fuzzball81@gmail.com>