### PR TITLE
New function to check if a commit exists on a given remote branch

### DIFF
--- a/git_wrapper/branch.py
+++ b/git_wrapper/branch.py
@@ -347,3 +347,22 @@ class GitBranch(object):
                 "Error: {error}".format(ref=ref, branch=branch, error=ex)
             )
             raise_from(exceptions.ResetException(msg), ex)
+
+    @reference_exists('remote_branch')
+    @reference_exists('hash_')
+    def remote_contains(self, remote_branch, hash_):
+        """Check if a commit hash is present on a remote branch
+
+           :param str remote_branch: Remote branch to check
+           :param str hash_: Commit hash to check if present
+        """
+        # When used with a specific branch name, this command will
+        # return either an empty string if the commit isn't present, or
+        # the branch name provided
+        result = self.git_repo.git.branch(
+            "-r", "--contains", hash_, remote_branch
+        )
+        if result:
+            return True
+        else:
+            return False

--- a/integration_tests/test_branch.py
+++ b/integration_tests/test_branch.py
@@ -147,3 +147,23 @@ def test_create_branch(repo_root):
     repo.branch.create(branch_name, "0.1.0", True)
     assert branch_name in repo.repo.branches
     assert repo.repo.branches[branch_name].commit.hexsha == tag_0_1_0_hexsha
+
+
+def test_remote_contains(repo_root, patch_cleanup, datadir):
+    repo = GitRepo(repo_root)
+    remote_branch = "origin/master"
+
+    # 1. Check a known commit
+    assert repo.branch.remote_contains(
+        remote_branch, "fc88bcb3158187ba9566dad896e3c688d8bc5109"
+    ) is True
+
+    # 2. Confirm new commit doesn't exist on the remote
+    test_branch = "test_contains"
+    patch_path = (datadir / "test.patch")
+    repo.git.branch(test_branch, "0.1.0")  # For patch to apply cleanly
+    repo.branch.apply_patch(test_branch, patch_path)
+
+    assert repo.branch.remote_contains(
+        remote_branch, repo.repo.head.object.hexsha
+    ) is False


### PR DESCRIPTION
This will be helpful to determine whether to push a rebase after e.g. dropping a downstream-only patch. If the new upstream commit is not on the remote, we know we need to push the rebase results for consistency.