### PR TITLE
Preserve square brackets in commit messages when applying patches

### DIFF
--- a/tests/test_branch.py
+++ b/tests/test_branch.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 """Tests for GitCommit"""
 
-from mock import Mock, patch
+from mock import ANY, Mock, patch
 
 import git
 import pytest
@@ -251,13 +251,31 @@ def test_apply_patch(mock_repo):
     """
     GIVEN GitRepo initialized with a path and repo
     WHEN apply_patch is called with a valid branch_name and valid path
-    THEN git.am is called
+    THEN git.am is called with only one argument (path) and no options
     """
     repo = GitRepo('./', mock_repo)
 
     with patch('git.repo.fun.name_to_object'):
         repo.branch.apply_patch('test_branch', './requirements.txt')
     assert repo.git.am.called is True
+    # The path gets translated to a full path which will change on every
+    # system so we only check there was one argument only, with no other flags
+    repo.git.am.assert_called_with(ANY)
+
+
+def test_apply_patch_with_brackets_preserved(mock_repo):
+    """
+    GIVEN GitRepo initialized with a path and repo
+    WHEN apply_patch is called with valid parameters
+    AND keep_square_brackets is set to True
+    THEN git.am is called with the --keep-non-patch option
+    """
+    repo = GitRepo('./', mock_repo)
+
+    with patch('git.repo.fun.name_to_object'):
+        repo.branch.apply_patch('test_branch', './requirements.txt', keep_square_brackets=True)
+    assert repo.git.am.called is True
+    repo.git.am.assert_called_with('--keep-non-patch', ANY)
 
 
 def test_apply_patch_wrong_branch_name(mock_repo):


### PR DESCRIPTION
Commit messages in patches can include useful information between square brackets such as a bug/task reference or downstream-only status. The default git-am command strips those out but it is useful information users may want to preserve; this patch adds a parameter to enable doing that without changing the existing behaviour.