### PR TITLE
Add function to grep logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ wheels/
 *.egg-info/
 .installed.cfg
 *.egg
+*~
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/git_wrapper/branch.py
+++ b/git_wrapper/branch.py
@@ -3,7 +3,6 @@
 
 import re
 import os
-from string import Template
 
 import git
 from future.utils import raise_from
@@ -245,68 +244,17 @@ class GitBranch(object):
             msg = "Reversing diff failed. Error: {0}".format(ex)
             raise_from(exceptions.RevertException(msg), ex)
 
-    @reference_exists('hash_from')
-    @reference_exists('hash_to')
     def log_diff(self, hash_from, hash_to, pattern="$full_message"):
-        """Return a list of strings for log entries between two hashes.
-
-           Any of the following placeholders may be used in the pattern:
-             * $hash The full commit hash
-             * $short_hash The short commit hash, similar to --abbrev-commit
-             * $message The commit message
-             * $summary First line of the commit message
-             * $full_message Complete commit info with hash, author, message.
-               Similar to default "git log" ouput
-             * $author Commit author
-             * $date Date the commit was authored
-
-           :param str hash_from: A commit hash
-           :param str hash_to: A commit hash
-           :param str pattern: Formatter containing any of the placeholders above
-        """
-        range_ = "{0}..{1}".format(hash_from, hash_to)
-        commits = self.git_repo.repo.iter_commits(range_)
-        if not commits:
-            return []
-
-        # Prepare patterns
-        author_tpl = Template("$name <$email>")
-        full_message_tpl = Template(
-            "commit $hash\nAuthor: $author\nDate: $date\n\n$message"
-        )
-
-        # Parse the user-provided pattern
-        log = []
-        line_tpl = Template(pattern)
-        for c in commits:
-            c_author = author_tpl.safe_substitute(name=c.author.name,
-                                                  email=c.author.email)
-            c_date = c.authored_datetime.strftime("%a %b %d %H:%M:%S %Y %z")
-
-            placeholders = {"short_hash": c.hexsha[0:7],
-                            "hash": c.hexsha,
-                            "message": c.message,
-                            "summary": c.summary,
-                            "author": c_author,
-                            "date": c_date}
-
-            full_message = full_message_tpl.safe_substitute(placeholders)
-            placeholders["full_message"] = full_message
-
-            line = line_tpl.safe_substitute(placeholders)
-            log.append(line)
-
-        return log
+        """DEPRECATED. Use GitRepo.log.log_diff instead."""
+        self.logger.warning("DEPRECATED. GitRepo.branch.log_diff is deprecated, "
+                            "Use GitRepo.log.log_diff instead.")
+        return self.git_repo.log.log_diff(hash_from, hash_to, pattern)
 
     def short_log_diff(self, hash_from, hash_to):
-        """Return a list of strings for log entries between two hashes.
-
-           Log entries will be returned in the "<short_hash> <summary>" format.
-
-           :param str hash_from: A commit hash
-           :param str hash_to: A commit hash
-        """
-        return self.log_diff(hash_from, hash_to, "$short_hash $summary")
+        """DEPRECATED. Use GitRepo.log.short_log_diff instead."""
+        self.logger.warning("DEPRECATED. GitRepo.branch.short_log_diff is deprecated, "
+                            "Use GitRepo.log.short_log_diff instead.")
+        return self.git_repo.log.short_log_diff(hash_from, hash_to)
 
     def hard_reset(self, branch="master", remote="origin",
                    remote_branch="master", refresh=True):

--- a/git_wrapper/log.py
+++ b/git_wrapper/log.py
@@ -1,0 +1,81 @@
+#! /usr/bin/env python
+"""This module acts as an interface for acting on git logs"""
+
+from string import Template
+
+from git_wrapper.utils.decorators import reference_exists
+
+
+class GitLog(object):
+
+    def __init__(self, git_repo, logger):
+        """Constructor for GitLog object
+
+            :param repo.GitRepo git_repo: An already constructed GitRepo object
+            :param logging.Logger logger: A pre-configured Python Logger object
+        """
+        self.git_repo = git_repo
+        self.logger = logger
+
+    @reference_exists('hash_from')
+    @reference_exists('hash_to')
+    def log_diff(self, hash_from, hash_to, pattern="$full_message"):
+        """Return a list of strings for log entries between two hashes.
+
+           Any of the following placeholders may be used in the pattern:
+             * $hash The full commit hash
+             * $short_hash The short commit hash, similar to --abbrev-commit
+             * $message The commit message
+             * $summary First line of the commit message
+             * $full_message Complete commit info with hash, author, message.
+               Similar to default "git log" ouput
+             * $author Commit author
+             * $date Date the commit was authored
+
+           :param str hash_from: A commit hash
+           :param str hash_to: A commit hash
+           :param str pattern: Formatter containing any of the placeholders above
+        """
+        range_ = "{0}..{1}".format(hash_from, hash_to)
+        commits = self.git_repo.repo.iter_commits(range_)
+        if not commits:
+            return []
+
+        # Prepare patterns
+        author_tpl = Template("$name <$email>")
+        full_message_tpl = Template(
+            "commit $hash\nAuthor: $author\nDate: $date\n\n$message"
+        )
+
+        # Parse the user-provided pattern
+        log = []
+        line_tpl = Template(pattern)
+        for c in commits:
+            c_author = author_tpl.safe_substitute(name=c.author.name,
+                                                  email=c.author.email)
+            c_date = c.authored_datetime.strftime("%a %b %d %H:%M:%S %Y %z")
+
+            placeholders = {"short_hash": c.hexsha[0:7],
+                            "hash": c.hexsha,
+                            "message": c.message,
+                            "summary": c.summary,
+                            "author": c_author,
+                            "date": c_date}
+
+            full_message = full_message_tpl.safe_substitute(placeholders)
+            placeholders["full_message"] = full_message
+
+            line = line_tpl.safe_substitute(placeholders)
+            log.append(line)
+
+        return log
+
+    def short_log_diff(self, hash_from, hash_to):
+        """Return a list of strings for log entries between two hashes.
+
+           Log entries will be returned in the "<short_hash> <summary>" format.
+
+           :param str hash_from: A commit hash
+           :param str hash_to: A commit hash
+        """
+        return self.log_diff(hash_from, hash_to, "$short_hash $summary")

--- a/git_wrapper/repo.py
+++ b/git_wrapper/repo.py
@@ -11,6 +11,7 @@ from future.utils import raise_from
 from git_wrapper.branch import GitBranch
 from git_wrapper.commit import GitCommit
 from git_wrapper import exceptions
+from git_wrapper.log import GitLog
 from git_wrapper.remote import GitRemote
 from git_wrapper.tag import GitTag
 
@@ -28,6 +29,7 @@ class GitRepo(object):
         self.__repo = None  # Added to clear pylint warnings
         self._branch = None
         self._commit = None
+        self._log = None
         self._remote = None
         self._tag = None
 
@@ -212,3 +214,20 @@ class GitRepo(object):
         if not isinstance(new_tag, GitTag):
             raise TypeError("Tag must be a GitTag object.")
         self._tag = new_tag
+
+    @property
+    def log(self):
+        """Return object to act on the repo's logs"""
+        if not self._log:
+            self._log = GitLog(git_repo=self, logger=self.logger)
+        return self._log
+
+    @log.setter
+    def log(self, new_log):
+        """Set up object to interact with Logs
+
+            :param git_wrapper.log.GitLog new_log: Pre-constructed GitLog object
+        """
+        if not isinstance(new_log, GitLog):
+            raise TypeError("Log must be a GitLog object.")
+        self._log = new_log

--- a/integration_tests/test_branch.py
+++ b/integration_tests/test_branch.py
@@ -64,37 +64,6 @@ def test_abort(repo_root, patch_cleanup, datadir):
     assert "Test patch" not in repo.repo.head.object.message
 
 
-def test_log_diff(repo_root):
-    repo = GitRepo(repo_root)
-
-    log_diff = repo.branch.short_log_diff(
-        "155b270a26c5c6cc5e90281fb1a741b293364caa",
-        "964aaddddadfbf646fea6a4549e4cb3661a35712"
-    )
-
-    assert len(log_diff) == 2
-    assert log_diff[0] == "964aadd Drop py34"
-    assert log_diff[1] == "5ded3c1 Add basic logging in more places"
-
-
-def test_log_diff_no_results(repo_root):
-    repo = GitRepo(repo_root)
-
-    log_diff = repo.branch.log_diff("0.1.0", "0.1.0")
-
-    assert len(log_diff) == 0
-
-
-def test_log_diff_wrong_hash(repo_root):
-    repo = GitRepo(repo_root)
-
-    with pytest.raises(exceptions.ReferenceNotFoundException):
-        repo.branch.log_diff("0.1.0", "123456789z")
-
-    with pytest.raises(exceptions.ReferenceNotFoundException):
-        repo.branch.log_diff("123456789z", "0.1.0")
-
-
 def test_reset(repo_root):
     repo = GitRepo(repo_root)
     branch_name = "test_reset"

--- a/integration_tests/test_log.py
+++ b/integration_tests/test_log.py
@@ -33,3 +33,35 @@ def test_log_diff_wrong_hash(repo_root):
 
     with pytest.raises(exceptions.ReferenceNotFoundException):
         repo.branch.log_diff("123456789z", "0.1.0")
+
+
+def test_log_grep(repo_root):
+    repo = GitRepo(repo_root)
+
+    commits = repo.log.grep_for_commits('master', "Initial commit")
+
+    assert len(commits) == 1
+    assert commits[0] == "ba82064c5fea1fc40270fb2748d5d8a783397609"
+
+
+def test_log_grep_empty(repo_root):
+    repo = GitRepo(repo_root)
+
+    commits = repo.log.grep_for_commits('master', "somethingthatcannotbefound", True)
+
+    assert len(commits) == 0
+
+
+def test_log_grep_with_path(repo_root):
+    repo = GitRepo(repo_root)
+
+    commits = repo.log.grep_for_commits('master', "Initial", path=".gitignore")
+
+    assert len(commits) == 1
+
+
+def test_log_grep_badpath(repo_root):
+    repo = GitRepo(repo_root)
+
+    with pytest.raises(exceptions.FileDoesntExistException):
+        repo.log.grep_for_commits('master', "Initial", path="badpath")

--- a/integration_tests/test_log.py
+++ b/integration_tests/test_log.py
@@ -1,0 +1,35 @@
+import pytest
+
+from git_wrapper import exceptions
+from git_wrapper.repo import GitRepo
+
+
+def test_log_diff(repo_root):
+    repo = GitRepo(repo_root)
+
+    log_diff = repo.branch.short_log_diff(
+        "155b270a26c5c6cc5e90281fb1a741b293364caa",
+        "964aaddddadfbf646fea6a4549e4cb3661a35712"
+    )
+
+    assert len(log_diff) == 2
+    assert log_diff[0] == "964aadd Drop py34"
+    assert log_diff[1] == "5ded3c1 Add basic logging in more places"
+
+
+def test_log_diff_no_results(repo_root):
+    repo = GitRepo(repo_root)
+
+    log_diff = repo.branch.log_diff("0.1.0", "0.1.0")
+
+    assert len(log_diff) == 0
+
+
+def test_log_diff_wrong_hash(repo_root):
+    repo = GitRepo(repo_root)
+
+    with pytest.raises(exceptions.ReferenceNotFoundException):
+        repo.branch.log_diff("0.1.0", "123456789z")
+
+    with pytest.raises(exceptions.ReferenceNotFoundException):
+        repo.branch.log_diff("123456789z", "0.1.0")

--- a/tests/test_branch.py
+++ b/tests/test_branch.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Tests for GitCommit"""
+"""Tests for GitBranch"""
 
 from mock import ANY, Mock, patch
 
@@ -539,97 +539,6 @@ def test_reverse_diff_error(mock_repo):
 
     with pytest.raises(exceptions.RevertException):
         repo.branch.reverse_diff('./requirements.txt')
-
-
-def test_log_diff(mock_repo, fake_commits):
-    """
-    GIVEN GitRepo initialized with a path and repo
-    WHEN log_diff is called with two valid hashes
-    THEN a list of log entries is returned
-    """
-    mock_repo.iter_commits.return_value = fake_commits
-    repo = GitRepo('./', mock_repo)
-
-    with patch('git.repo.fun.name_to_object'):
-        log_diff = repo.branch.log_diff('12345', '54321')
-
-    assert len(log_diff) == 3
-    assert log_diff[2] == (
-        "commit 0020000000000000000\n"
-        "Author: Test Author <testauthor@example.com>\n"
-        "Date: Wed Dec 05 10:36:19 2018 \n\n"
-        "This is a commit message (#2)\nWith some details."
-    )
-
-
-def test_short_log_diff(mock_repo, fake_commits):
-    """
-    GIVEN GitRepo initialized with a path and repo
-    WHEN short_log_diff is called with two valid hashes
-    THEN a list of log entries is returned
-    """
-    mock_repo.iter_commits.return_value = fake_commits
-    repo = GitRepo('./', mock_repo)
-
-    with patch('git.repo.fun.name_to_object'):
-        log_diff = repo.branch.short_log_diff('12345', '54321')
-
-    assert len(log_diff) == 3
-    assert log_diff == ["0000000 This is a commit message (#0)",
-                        "0010000 This is a commit message (#1)",
-                        "0020000 This is a commit message (#2)"]
-
-
-def test_log_diff_with_pattern(mock_repo, fake_commits):
-    """
-    GIVEN GitRepo initialized with a path and repo
-    WHEN log_diff is called with two valid hashes and a pattern
-    THEN a list of log entries is returned
-    """
-    mock_repo.iter_commits.return_value = fake_commits
-    repo = GitRepo('./', mock_repo)
-
-    with patch('git.repo.fun.name_to_object'):
-        log_diff = repo.branch.log_diff('12345', '54321',
-                                        pattern="$hash $author")
-
-    assert log_diff == [
-        "0000000000000000000 Test Author <testauthor@example.com>",
-        "0010000000000000000 Test Author <testauthor@example.com>",
-        "0020000000000000000 Test Author <testauthor@example.com>"
-    ]
-
-
-def test_log_diff_no_results(mock_repo):
-    """
-    GIVEN GitRepo initialized with a path and repo
-    WHEN log_diff is called with two valid hashes
-    AND there are no results
-    THEN an empty list is returned
-    """
-    mock_repo.iter_commits.return_value = []
-    repo = GitRepo('./', mock_repo)
-
-    with patch('git.repo.fun.name_to_object'):
-        log_diff = repo.branch.log_diff('12345', '12345')
-
-    assert log_diff == []
-
-
-def test_log_diff_invalid_hash(mock_repo):
-    """
-    GIVEN GitRepo initialized with a path and repo
-    WHEN log_diff is called with a invalid hash
-    THEN a ReferenceNotFoundException is raised
-    """
-    repo = GitRepo('./', mock_repo)
-
-    with patch('git.repo.fun.name_to_object') as mock_name_to_object:
-        with pytest.raises(exceptions.ReferenceNotFoundException):
-            mock_name_to_object.side_effect = git.exc.BadName()
-            repo.branch.log_diff('doesNotExist', '12345')
-
-    assert mock_repo.iter_commits.called is False
 
 
 def test_reset(mock_repo):

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -99,3 +99,64 @@ def test_log_diff_invalid_hash(mock_repo):
             repo.branch.log_diff('doesNotExist', '12345')
 
     assert mock_repo.iter_commits.called is False
+
+
+def test_log_grep(mock_repo):
+    """
+    GIVEN GitRepo is initialized with a path and repo
+    WHEN log.log_grep_for_commits is called with valid parameters
+    THEN a list of commits is returned
+    """
+    mock_repo.git.log.return_value = "commit1\ncommit2\ncommit3"
+    repo = GitRepo(repo=mock_repo)
+
+    with patch('git.repo.fun.name_to_object'):
+        results = repo.log.grep_for_commits("test_branch", 'test')
+
+    assert results == ["commit1", "commit2", "commit3"]
+
+
+def test_log_grep_no_commits(mock_repo):
+    """
+    GIVEN GitRepo is initialized with a path and repo
+    WHEN log.log_grep_for_commits is called with valid parameters
+    AND git.log only returns a breakline
+    THEN an empty list is returned
+    """
+    mock_repo.git.log.return_value = ""
+    repo = GitRepo(repo=mock_repo)
+
+    with patch('git.repo.fun.name_to_object'):
+        results = repo.log.grep_for_commits("test_branch", 'test')
+
+    assert results == []
+
+
+def test_log_grep_with_path(mock_repo):
+    """
+    GIVEN GitRepo is initialized with a path and repo
+    WHEN log.log_grep_for_commits is called with a valid path
+    THEN a list of commits is returned
+    """
+    mock_repo.git.log.return_value = "commit1"
+    mock_repo.tree.return_value = ['testpath', 'test2']
+    repo = GitRepo(repo=mock_repo)
+
+    with patch('git.repo.fun.name_to_object'):
+        results = repo.log.grep_for_commits("test_branch", 'test', True, 'testpath')
+
+    assert results == ["commit1"]
+
+
+def test_log_grep_bad_path(mock_repo):
+    """
+    GIVEN GitRepo is initialized with a path and repo
+    WHEN log.log_grep_for_commits is called with an invalid path
+    THEN a FileDoesntExist exception is raised
+    """
+    mock_repo.tree.return_value = ['testpath', 'testpath2']
+    repo = GitRepo(repo=mock_repo)
+
+    with patch('git.repo.fun.name_to_object'):
+        with pytest.raises(exceptions.FileDoesntExistException):
+            repo.log.grep_for_commits("test_branch", 'test', True, 'wrongpath')

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,0 +1,101 @@
+#! /usr/bin/env python
+"""Tests for GitLog"""
+
+from mock import patch
+
+import git
+import pytest
+
+from git_wrapper.repo import GitRepo
+from git_wrapper import exceptions
+
+
+def test_log_diff(mock_repo, fake_commits):
+    """
+    GIVEN GitRepo initialized with a path and repo
+    WHEN log_diff is called with two valid hashes
+    THEN a list of log entries is returned
+    """
+    mock_repo.iter_commits.return_value = fake_commits
+    repo = GitRepo('./', mock_repo)
+
+    with patch('git.repo.fun.name_to_object'):
+        log_diff = repo.branch.log_diff('12345', '54321')
+
+    assert len(log_diff) == 3
+    assert log_diff[2] == (
+        "commit 0020000000000000000\n"
+        "Author: Test Author <testauthor@example.com>\n"
+        "Date: Wed Dec 05 10:36:19 2018 \n\n"
+        "This is a commit message (#2)\nWith some details."
+    )
+
+
+def test_short_log_diff(mock_repo, fake_commits):
+    """
+    GIVEN GitRepo initialized with a path and repo
+    WHEN short_log_diff is called with two valid hashes
+    THEN a list of log entries is returned
+    """
+    mock_repo.iter_commits.return_value = fake_commits
+    repo = GitRepo('./', mock_repo)
+
+    with patch('git.repo.fun.name_to_object'):
+        log_diff = repo.branch.short_log_diff('12345', '54321')
+
+    assert len(log_diff) == 3
+    assert log_diff == ["0000000 This is a commit message (#0)",
+                        "0010000 This is a commit message (#1)",
+                        "0020000 This is a commit message (#2)"]
+
+
+def test_log_diff_with_pattern(mock_repo, fake_commits):
+    """
+    GIVEN GitRepo initialized with a path and repo
+    WHEN log_diff is called with two valid hashes and a pattern
+    THEN a list of log entries is returned
+    """
+    mock_repo.iter_commits.return_value = fake_commits
+    repo = GitRepo('./', mock_repo)
+
+    with patch('git.repo.fun.name_to_object'):
+        log_diff = repo.branch.log_diff('12345', '54321',
+                                        pattern="$hash $author")
+
+    assert log_diff == [
+        "0000000000000000000 Test Author <testauthor@example.com>",
+        "0010000000000000000 Test Author <testauthor@example.com>",
+        "0020000000000000000 Test Author <testauthor@example.com>"
+    ]
+
+
+def test_log_diff_no_results(mock_repo):
+    """
+    GIVEN GitRepo initialized with a path and repo
+    WHEN log_diff is called with two valid hashes
+    AND there are no results
+    THEN an empty list is returned
+    """
+    mock_repo.iter_commits.return_value = []
+    repo = GitRepo('./', mock_repo)
+
+    with patch('git.repo.fun.name_to_object'):
+        log_diff = repo.branch.log_diff('12345', '12345')
+
+    assert log_diff == []
+
+
+def test_log_diff_invalid_hash(mock_repo):
+    """
+    GIVEN GitRepo initialized with a path and repo
+    WHEN log_diff is called with a invalid hash
+    THEN a ReferenceNotFoundException is raised
+    """
+    repo = GitRepo('./', mock_repo)
+
+    with patch('git.repo.fun.name_to_object') as mock_name_to_object:
+        with pytest.raises(exceptions.ReferenceNotFoundException):
+            mock_name_to_object.side_effect = git.exc.BadName()
+            repo.branch.log_diff('doesNotExist', '12345')
+
+    assert mock_repo.iter_commits.called is False


### PR DESCRIPTION
Also move the existing log functions into a new GitLog component.

To help with reviewing this PR is broken down into two commits:
- The first one moves the existing log functions into a GitLog component. This only moves the existing code around, there are no functional changes to the contents.
- The second commit adds the new grep functionality and associated tests.