### PR TITLE
Mergify update

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -7,10 +7,11 @@ pull_request_rules:
       conditions:
           - label!=no-mergify
           - '#approved-reviews-by>=1'
-          - status-success=Run tests / test (2.7)
-          - status-success=Run tests / test (3.6)
-          - status-success=Run tests / test (3.8)
-          - status-success=Run tests / test (3.9)
-          - status-success=Run tests / flake8
-          - status-success=Run tests / integration
+          - check-success=flake8
+          - check-success=integration
+          - check-success=test (2.7)
+          - check-success=test (3.6)
+          - check-success=test (3.7)
+          - check-success=test (3.8)
+          - check-success=test (3.9)
       name: default


### PR DESCRIPTION
The conditions should use 'check-success' not 'status-success.'

Without manually individually indicating which jobs need to pass, this doesn't work.

It doesn't appear to work with the long names either:

Short names (OK): https://github.com/jpichon/git_wrapper/pull/3/checks
Long names (not OK): https://github.com/jpichon/git_wrapper/pull/4/checks
Long name, only one (not OK): https://github.com/jpichon/git_wrapper/pull/5/checks

https://docs.mergify.io/conditions/#validating-all-status-checks suggests that expecting "All jobs named 'tests''" to work would bite us because Mergify doesn't know in advance how many status checks are expected to run, so it might validate after only one or two have returned. I would have expected listing all the long names to work based on the screenshot but that doesn't seem to be the case from my testing (cf. results above).