### PR TITLE
Create GitHub Action CI job for twine check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,3 +51,17 @@ jobs:
             pip install tox tox-gh-actions
         - name: Run integration tests
           run: tox -eintegration
+    twine:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v2
+        - name: Setup Python
+          uses: actions/setup-python@v2
+          with:
+            python-version: 3.9
+        - name: Install Tox and any other packages
+          run: |
+            python -m pip install --upgrade pip
+            pip install tox tox-gh-actions
+        - name: Run twine-check
+          run: tox -etwine

--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,7 @@ ENV/
 # Pipenv
 Pipfile
 Pipfile.lock
+
+# auto-generated
+ChangeLog
+AUTHORS

--- a/README.rst
+++ b/README.rst
@@ -74,14 +74,9 @@ Pushing a new release
 
    You may want to check the HISTORY.rst file renders correctly before
    committing, as the twine upload will fail later if it
-   doesn't. Install one of these::
+   doesn't::
 
-    # dnf install python3-readme-renderer
-    $ pip install readme-renderer
-
-   Then run the following command::
-
-    $ python -m readme_renderer HISTORY.rst -o /tmp/HISTORY.html
+    $ tox -etwine
 
 2. Once that's merged, tag that patch and push the new tag to the repo
 3. Run the following commands::

--- a/setup.py
+++ b/setup.py
@@ -7,5 +7,6 @@ from setuptools import setup
 
 setup(
     setup_requires=['pbr'],
-    pbr=True
+    pbr=True,
+    long_description_content_type='text/x-rst'
 )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,3 +4,4 @@ pytest-datadir
 pytest-runner
 mock>=2.0.0
 flake8
+twine

--- a/tox.ini
+++ b/tox.ini
@@ -26,3 +26,8 @@ commands =
     /usr/bin/find . -name '*.pyc' -delete  # Avoid issues with pytests conf file discovery
     /usr/bin/podman build -t git_wrapper_integration_tests .
     /usr/bin/podman run git_wrapper_integration_tests /bin/sh -c "pytest -k integration_tests integration_tests"  # Ensure we only run the integration tests
+
+[testenv:twine]
+commands =
+    python setup.py sdist bdist_wheel
+    twine check --strict dist/*


### PR DESCRIPTION
To prevent upload failures to PyPi due to linting
errors in .rst files, a CI job for running twine
check was made into a GitHub Action

twine check effectively removes the need for an
additional dep for linting .rst files

The variable long_description_content_type was
added to setup.cfg in order to pass twine check
--strict