### PR TITLE
Modify to allow tag listing

### DIFF
--- a/git_wrapper/tag.py
+++ b/git_wrapper/tag.py
@@ -72,3 +72,14 @@ class GitTag(object):
                 self.git_repo.git.push(remote, name)
         except git.GitCommandError as ex:
             raise_from(exceptions.PushException(msg), ex)
+
+    def names(self):
+        """List git tags in the repository."""
+        try:
+            tags_list = [x.name for x in self.git_repo.repo.tags]
+        except git.GitCommandError as ex:
+            repo_path = self.git_repo.repo.working_dir
+            msg = "Error listing tags for {repo}. Error: {error}".format(error=ex, repo=repo_path)
+            raise_from(exceptions.TaggingException(msg), ex)
+
+        return tags_list

--- a/integration_tests/test_tag.py
+++ b/integration_tests/test_tag.py
@@ -11,6 +11,9 @@ def test_tag(repo_root):
     repo.git.checkout("master")
     head = repo.repo.head.object.hexsha
 
+    # Test tag listing function names() by checking for tag name in test repo
+    assert '0.2.4' in repo.tag.names()
+
     # Test tag creation by tagging the current head
     repo.tag.create("test_tag", head)
 


### PR DESCRIPTION
Adds the method list_tags() to the GitTag class to list all tags in a repo object.