### PR TITLE
Add publish action.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,28 @@
+name: Upload Package to Pypi
+
+on:
+  release:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r test-requirements.txt
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/*

--- a/README.rst
+++ b/README.rst
@@ -71,21 +71,9 @@ Pushing a new release
 *********************
 
 1. Prepare a patch to update the version number (`example`_)
-
-   You may want to check the HISTORY.rst file renders correctly before
-   committing, as the twine upload will fail later if it
-   doesn't::
-
-    $ tox -etwine
-
 2. Once that's merged, tag that patch and push the new tag to the repo
-3. Run the following commands::
+3. Github Actions will then automatically build and publish a new release.
 
-    $ rm dist/*
-    $ python setup.py sdist bdist_wheel
-    $ twine upload --verbose dist/*
-
-(You need to have a PyPI account with the right permissions for that last step.)
 
 .. _example: https://github.com/release-depot/git_wrapper/commit/fc88bcb3158187ba9566dad896e3c688d8bc5109
 


### PR DESCRIPTION
Remove some manual steps/effort by having new releases be published
automatically to pypi.

Signed-off-by: Jason Guiditta <jguiditt@redhat.com>