### PR TITLE
Update outdated development/contrib instructions

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -64,11 +64,15 @@ Ready to contribute? Here's how to set up `git_wrapper` for local development.
 
     $ git clone git@github.com:your_name_here/git_wrapper.git
 
-3. Use pipenv via the Makefile to setup a new virtualenv. Pipenv will create a new virtualenv with packages at the correct versions.
-   Assuming you have pipenv installed, this is how you set up your fork for local development::
+3. Use the Makefile or virtualenv to setup a new virtualenv::
 
     $ make dev
-    $ pipenv shell
+
+   or::
+
+    $ virtualenv .venv
+    $ source .venv/bin/activate
+    $ pip install -r requirements.txt
 
 4. Create a branch for local development::
 
@@ -83,6 +87,10 @@ Ready to contribute? Here's how to set up `git_wrapper` for local development.
     $ make test
     $ tox
 
+   For the integration tests::
+
+    $ tox -eintegration  # For docker
+    $ tox -eintegration_podman  # For podman
 
 6. Commit your changes and push your branch to GitHub::
 
@@ -99,8 +107,7 @@ Before you submit a pull request, check that it meets these guidelines:
 
 1. The pull request should include tests.
 2. If the pull request adds functionality, the docs should be updated. Put
-   your new functionality into a function with a docstring, and add the
-   feature to the list in README.rst.
+   your new functionality into a function with a docstring.
 3. The pull request should work for Python 2.7 and 3.6+. The tox
    environments and Github Actions are set up to check this.
 

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,10 @@ Python wrapper around GitPython
 Features
 --------
 
-* TODO
+See `documentation`_.
+
+.. _`documentation`: https://git-wrapper.readthedocs.io/en/latest/source/modules.html
+
 
 Notes
 -----
@@ -32,23 +35,7 @@ syntax and features may be compatible.
 Development
 -----------
 
-There are several dependencies needed to build and work on git_wrapper.  Using
-your distribution's package manager, install these system packages::
-
-  GitPython
-
-git_wrapper uses the upcoming standard of Pipfiles via pipenv.  This is integrated
-into our Makefile and once you have the above dependencies, you can simply run::
-
-  make dev
-
-This will install our dev environment for the package via pipenv.  It is installed
-with --user, so it does not affect your site-packages.  Pipenv creates a unique virtualenv
-for us, which you can activate via::
-
-  pipenv shell
-
-See the `pipenv documentation <https://docs.pipenv.org/>`_ for more detail.
+See CONTRIBUTING.rst.
 
 Documentation
 *************


### PR DESCRIPTION
Pipenv was removed in an early commit (bb5528) but the documentation wasn't updated to reflect that.