### PR TITLE
Improvements to publish github action.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,12 +1,11 @@
-name: Upload Package to Pypi
+name: Upload Package to PyPI and TestPyPI
 
 on:
-  release:
+  push:
   workflow_dispatch:
 
 jobs:
   deploy:
-
     runs-on: ubuntu-latest
 
     steps:
@@ -14,15 +13,22 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.x'
+        python-version: '3.9'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -r test-requirements.txt
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        python -m build
-        twine upload dist/*
+    - name: Build package
+      run:  python -m build
+    - name: Publish to Test PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.TEST_PYPI_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
This patch attempts to any remaining issues from #88, specifically
the mutliple runs (by specifying one one python version to build for)
and not requiring a 'click release button' step to be added to our
process. We may, in a future patch, decide to do more around the
github 'release' concept, which is separate from our current process
of doing a release to pypi when the project is tagged.

This patch also adds a push to the test instance of pypi for quicker
and more frequent verification that pulishing works as expected, and
to give us an easy way for new features to be tested by users between
official tags/releases.

This patch uses the github action built by pypa instead of twine
directly, as we did before, following official docs [1],[2].

[1]
https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
[2] https://github.com/pypa/gh-action-pypi-publish

Signed-off-by: Jason Guiditta <jguiditt@redhat.com>