### PR TITLE
Fix deploy job.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r test-requirements.txt
+        pip install -r dist-requirements.txt
     - name: Build package
       run:  python -m build
     - name: Publish to Test PyPI


### PR DESCRIPTION
We were installing the test requirements instead of dist, so the build
would fail.

Signed-off-by: Jason Guiditta <jguiditt@redhat.com>