### PR TITLE
Change how we generate version for test pypi builds.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,9 +18,17 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r dist-requirements.txt
+    - name: Create Environment Variable For Test PyPI Builds
+      if: startsWith(github.ref, 'refs/tags/') != true
+      shell: bash
+      run: |
+        echo 'SCM_NO_LOCAL_SCHEME=true' >> $GITHUB_ENV
+    - name: Check environment variable
+      run: echo "${{ env.SCM_NO_LOCAL_SCHEME}}"
     - name: Build package
       run:  python -m build
     - name: Publish to Test PyPI
+      if: startsWith(github.ref, 'refs/tags/') != true
       uses: pypa/gh-action-pypi-publish@master
       with:
         user: __token__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,4 +6,3 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools_scm]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,18 @@
 # -*- coding: utf-8 -*-
 
 """The setup script."""
+import os
 
 from setuptools import setup
 
-setup()
+
+def check_if_scm():
+    if os.environ.get('SCM_NO_LOCAL_SCHEME'):
+        return "no-local-version"
+    else:
+        return "node-and-date"
+
+
+setup(
+    use_scm_version={'local_scheme': check_if_scm()}
+)


### PR DESCRIPTION
The tooling by default appends '+{hash}' to non-tagged builds,
which is not compliant with the format required by pypi. This
patch chops off the '+' bit, so you get a version like '0.2.9.dev5'
where 'dev5' is the number of commits from the last tag. Provided
github action puts the env var where the python tooling expects it,
this should solve the issue for test deploys (production is unchanged).

Signed-off-by: Jason Guiditta <jguiditt@redhat.com>