### PR TITLE
Change fetch-depth to get correct tag info for builds.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Set up Python
       uses: actions/setup-python@v2
       with:


### PR DESCRIPTION
The default setting of the checkout@v2 action sets this to
1, meaning it gets only the single commit and NO data that
setuptools_scm can use to determine what version to build.
According to the docs[1], setting this to 0 should return
the data we need.  Note that this should ONLY be needed for
the publish action, as the tests and twine check don't need
to care about the version data.

[1]
https://github.com/marketplace/actions/checkout#fetch-all-history-for-all-tags-and-branches

Signed-off-by: Jason Guiditta <jguiditt@redhat.com>