### PR TITLE
Use tox for make test target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ lint: ## check style with flake8
 	pipenv run tox -eflake8
 
 test: ## run tests quickly with the default Python
-	pipenv run pytest
+	pipenv run  tox -epy
 
 test-all: ## run tests on every Python version with tox
 	pipenv run tox


### PR DESCRIPTION
Noticed that when running tests, the current target fails
because of integration tests, which we don't want to run
for 'quick dev tests' anyway.

Signed-off-by: Jason Guiditta <jguiditt@redhat.com>