### PR TITLE
Remove python 2-specific code.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       runs-on: ubuntu-latest
       strategy:
         matrix:
-          python: [2.7, 3.6, 3.7, 3.8, 3.9]
+          python: [3.6, 3.7, 3.8, 3.9]
       steps:
         - uses: actions/checkout@v2
         - name: Setup Python

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -9,7 +9,6 @@ pull_request_rules:
           - '#approved-reviews-by>=2'
           - check-success=flake8
           - check-success=integration
-          - check-success=test (2.7)
           - check-success=test (3.6)
           - check-success=test (3.7)
           - check-success=test (3.8)

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -101,7 +101,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 2.7 and 3.6+. The tox
+3. The pull request should work for Python 3.6+. The tox
    environments and Github Actions are set up to check this.
 
 Tips

--- a/git_wrapper/branch.py
+++ b/git_wrapper/branch.py
@@ -5,7 +5,6 @@ import re
 import os
 
 import git
-from future.utils import raise_from
 
 from git_wrapper import exceptions
 from git_wrapper.utils.decorators import reference_exists
@@ -139,14 +138,14 @@ class GitBranch(object):
             self.git_repo.git.checkout(branch_name)
         except git.GitCommandError as ex:
             msg = "Could not checkout branch {name}. Error: {error}".format(name=branch_name, error=ex)
-            raise_from(exceptions.CheckoutException(msg), ex)
+            raise exceptions.CheckoutException(msg) from ex
 
         # Rebase
         try:
             self.git_repo.git.rebase(hash_)
         except git.GitCommandError as ex:
             msg = "Could not rebase hash {hash_} onto branch {name}. Error: {error}".format(hash_=hash_, name=branch_name, error=ex)
-            raise_from(exceptions.RebaseException(msg), ex)
+            raise exceptions.RebaseException(msg) from ex
 
         self.logger.debug("Successfully rebased branch %s to %s", branch_name, hash_)
 
@@ -156,7 +155,7 @@ class GitBranch(object):
             self.git_repo.git.rebase('--abort')
         except git.GitCommandError as ex:
             msg = "Rebase abort command failed. Error: {0}".format(ex)
-            raise_from(exceptions.AbortException(msg), ex)
+            raise exceptions.AbortException(msg) from ex
 
     @reference_exists('branch_name')
     def apply_patch(self, branch_name, path, keep_square_brackets=False):
@@ -174,7 +173,7 @@ class GitBranch(object):
             self.git_repo.git.checkout(branch_name)
         except git.GitCommandError as ex:
             msg = "Could not checkout branch {name}. Error: {error}".format(name=branch_name, error=ex)
-            raise_from(exceptions.CheckoutException(msg), ex)
+            raise exceptions.CheckoutException(msg) from ex
 
         # Apply the patch file
         try:
@@ -184,7 +183,7 @@ class GitBranch(object):
                 self.git_repo.git.am(full_path)
         except git.GitCommandError as ex:
             msg = "Could not apply patch {path} on branch {name}. Error: {error}".format(path=full_path, name=branch_name, error=ex)
-            raise_from(exceptions.ChangeNotAppliedException(msg), ex)
+            raise exceptions.ChangeNotAppliedException(msg) from ex
 
     @reference_exists('branch_name')
     def apply_diff(self, branch_name, diff_path, message, signoff=False):
@@ -209,14 +208,14 @@ class GitBranch(object):
             self.git_repo.git.checkout(branch_name)
         except git.GitCommandError as ex:
             msg = "Could not checkout branch {name}. Error: {error}".format(name=branch_name, error=ex)
-            raise_from(exceptions.CheckoutException(msg), ex)
+            raise exceptions.CheckoutException(msg) from ex
 
         # Apply the diff
         try:
             self.git_repo.git.apply(full_path)
         except git.GitCommandError as ex:
             msg = "Could not apply diff {path} on branch {name}. Error: {error}".format(path=full_path, name=branch_name, error=ex)
-            raise_from(exceptions.ChangeNotAppliedException(msg), ex)
+            raise exceptions.ChangeNotAppliedException(msg) from ex
 
         # The diff may have added new files, ensure they are staged
         self.git_repo.git.add(".")
@@ -230,7 +229,7 @@ class GitBranch(object):
             self.git_repo.git.am('--abort')
         except git.GitCommandError as ex:
             msg = "Failed to abort git am operation. Error: {0}".format(ex)
-            raise_from(exceptions.AbortException(msg), ex)
+            raise exceptions.AbortException(msg) from ex
 
     def reverse_diff(self, diff_path):
         """Reverse a diff that was applied to the workspace.
@@ -245,7 +244,7 @@ class GitBranch(object):
             self.git_repo.git.apply(full_path, reverse=True)
         except git.GitCommandError as ex:
             msg = "Reversing diff failed. Error: {0}".format(ex)
-            raise_from(exceptions.RevertException(msg), ex)
+            raise exceptions.RevertException(msg) from ex
 
     def log_diff(self, hash_from, hash_to, pattern="$full_message"):
         """DEPRECATED. Use GitRepo.log.log_diff instead."""
@@ -286,7 +285,7 @@ class GitBranch(object):
             commit = git.repo.fun.name_to_object(self.git_repo.repo, ref)
         except git.exc.BadName as ex:
             msg = "Could not find reference {0}.".format(ref)
-            raise_from(exceptions.ReferenceNotFoundException(msg), ex)
+            raise exceptions.ReferenceNotFoundException(msg) from ex
 
         try:
             # Preserve the reference name if there is one
@@ -303,7 +302,7 @@ class GitBranch(object):
                 "Could not checkout branch {branch}. Error: {error}".format(
                     branch=branch, error=ex)
             )
-            raise_from(exceptions.CheckoutException(msg), ex)
+            raise exceptions.CheckoutException(msg) from ex
 
         # Reset --hard to that reference
         try:
@@ -315,7 +314,7 @@ class GitBranch(object):
                 "Error resetting branch {branch} to {ref}. "
                 "Error: {error}".format(ref=ref, branch=branch, error=ex)
             )
-            raise_from(exceptions.ResetException(msg), ex)
+            raise exceptions.ResetException(msg) from ex
 
         # Return to the original head if required
         if not checkout:
@@ -326,7 +325,7 @@ class GitBranch(object):
                     "Could not checkout {orig}. Error: {error}".format(
                         orig=orig, error=ex)
                 )
-                raise_from(exceptions.CheckoutException(msg), ex)
+                raise exceptions.CheckoutException(msg) from ex
 
     @reference_exists('remote_branch')
     @reference_exists('hash_')

--- a/git_wrapper/commit.py
+++ b/git_wrapper/commit.py
@@ -2,7 +2,6 @@
 """This module acts as an interface for acting on git commits"""
 
 import git
-from future.utils import raise_from
 
 from git_wrapper import exceptions
 from git_wrapper.utils.decorators import reference_exists
@@ -31,7 +30,7 @@ class GitCommit(object):
             output = self.git_repo.git.describe('--all', sha).split('-g')
         except git.CommandError as ex:
             msg = "Error while running describe command on sha {sha}: {error}".format(sha=sha, error=ex)
-            raise_from(exceptions.DescribeException(msg), ex)
+            raise exceptions.DescribeException(msg) from ex
 
         if output:
             tag = output[0]
@@ -78,7 +77,7 @@ class GitCommit(object):
         except git.GitCommandError as ex:
             msg = "Revert failed for hash {hash_}. Error: {error}".format(
                 hash_=hash_, error=ex)
-            raise_from(exceptions.RevertException(msg), ex)
+            raise exceptions.RevertException(msg) from ex
 
         if message:
             commit = git.repo.fun.name_to_object(self.git_repo.repo, hash_)
@@ -125,14 +124,14 @@ class GitCommit(object):
             self.git_repo.git.checkout(branch_name)
         except git.GitCommandError as ex:
             msg = "Could not checkout branch {name}. Error: {error}".format(name=branch_name, error=ex)
-            raise_from(exceptions.CheckoutException(msg), ex)
+            raise exceptions.CheckoutException(msg) from ex
 
         # Cherry-pick
         try:
             self.git_repo.git.cherry_pick(sha)
         except git.GitCommandError as ex:
             msg = "Could not cherry-pick commit {sha} on {name}. Error: {error}".format(name=branch_name, sha=sha, error=ex)
-            raise_from(exceptions.ChangeNotAppliedException(msg), ex)
+            raise exceptions.ChangeNotAppliedException(msg) from ex
 
         self.logger.debug("Successfully cherry-picked commit %s on %s", sha, branch_name)
 
@@ -142,4 +141,4 @@ class GitCommit(object):
             self.git_repo.git.cherry_pick('--abort')
         except git.GitCommandError as ex:
             msg = "Cherrypick abort command failed. Error: {0}".format(ex)
-            raise_from(exceptions.AbortException(msg), ex)
+            raise exceptions.AbortException(msg) from ex

--- a/git_wrapper/remote.py
+++ b/git_wrapper/remote.py
@@ -2,7 +2,6 @@
 """This module acts as an interface for acting on git remotes"""
 
 import git
-from future.utils import raise_from
 
 from git_wrapper import exceptions
 
@@ -73,7 +72,7 @@ class GitRemote(object):
                                         url=remote.url,
                                         error=ex)
             )
-            raise_from(exceptions.RemoteException(msg), ex)
+            raise exceptions.RemoteException(msg) from ex
 
     def fetch_all(self):
         """Refresh all the repo's remotes.

--- a/git_wrapper/repo.py
+++ b/git_wrapper/repo.py
@@ -6,7 +6,6 @@ import os
 import shutil
 
 import git
-from future.utils import raise_from
 
 from git_wrapper.branch import GitBranch
 from git_wrapper.commit import GitCommit
@@ -100,7 +99,7 @@ class GitRepo(object):
                                                  bare=bare)
         except git.GitCommandError as ex:
             msg = "Error cloning repository {repo}".format(repo=clone_from)
-            raise_from(exceptions.RepoCreationException(msg), ex)
+            raise exceptions.RepoCreationException(msg) from ex
 
         return GitRepo(repo=repo)
 
@@ -146,7 +145,7 @@ class GitRepo(object):
                     r = self.repo.create_remote(name, url)
                 except git.GitCommandError as ex:
                     msg = "Issue with recreating remote {remote}. Error: {error}".format(remote=name, error=ex)
-                    raise_from(exceptions.RemoteException(msg), ex)
+                    raise exceptions.RemoteException(msg) from ex
 
     @property
     def remote(self):

--- a/git_wrapper/tag.py
+++ b/git_wrapper/tag.py
@@ -2,7 +2,6 @@
 """This module acts as an interface for acting on git tags"""
 
 import git
-from future.utils import raise_from
 
 from git_wrapper import exceptions
 from git_wrapper.utils.decorators import reference_exists
@@ -32,7 +31,7 @@ class GitTag(object):
             msg = "Error creating tag {name} on {ref}. Error: {error}".format(
                 name=name, ref=reference, error=ex
             )
-            raise_from(exceptions.TaggingException(msg), ex)
+            raise exceptions.TaggingException(msg) from ex
 
     @reference_exists('name')
     def delete(self, name):
@@ -46,7 +45,7 @@ class GitTag(object):
             msg = "Error deleting tag {name}. Error: {error}".format(
                 name=name, error=ex
             )
-            raise_from(exceptions.TaggingException(msg), ex)
+            raise exceptions.TaggingException(msg) from ex
 
     @reference_exists('name')
     def push(self, name, remote, dry_run=False):
@@ -71,7 +70,7 @@ class GitTag(object):
             else:
                 self.git_repo.git.push(remote, name)
         except git.GitCommandError as ex:
-            raise_from(exceptions.PushException(msg), ex)
+            raise exceptions.PushException(msg) from ex
 
     def names(self):
         """List git tags in the repository."""
@@ -80,6 +79,6 @@ class GitTag(object):
         except git.GitCommandError as ex:
             repo_path = self.git_repo.repo.working_dir
             msg = "Error listing tags for {repo}. Error: {error}".format(error=ex, repo=repo_path)
-            raise_from(exceptions.TaggingException(msg), ex)
+            raise exceptions.TaggingException(msg) from ex
 
         return tags_list

--- a/git_wrapper/utils/decorators.py
+++ b/git_wrapper/utils/decorators.py
@@ -4,7 +4,6 @@
 import inspect
 
 import git
-from future.utils import raise_from
 import wrapt
 
 from git_wrapper import exceptions
@@ -19,6 +18,6 @@ def reference_exists(ref):
             git.repo.fun.name_to_object(repo, all_args[ref])
         except git.exc.BadName as ex:
             msg = "Could not find %s %s." % (ref, all_args[ref])
-            raise_from(exceptions.ReferenceNotFoundException(msg), ex)
+            raise exceptions.ReferenceNotFoundException(msg) from ex
         return func(*args, **kwargs)
     return wrapper

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,8 +15,6 @@ classifiers =
     Intended Audience :: Developers
     License :: OSI Approved :: MIT License
     Natural Language :: English
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
@@ -30,7 +28,6 @@ package_dir =
 packages = find:
 install_requires =
     GitPython
-    future
     wrapt
 
 [options.extras_require]


### PR DESCRIPTION
Since we no longer support python 2, there is no need to use
things only needed for compatibility anymore.

Signed-off-by: Jason Guiditta <jguiditt@redhat.com>