### PR TITLE
Switch to f-string over .format method.

### DIFF
--- a/git_wrapper/log.py
+++ b/git_wrapper/log.py
@@ -82,7 +82,7 @@ class GitLog(object):
            :param str pattern: Formatter containing any of the placeholders above
            :return: list of strings
         """
-        range_ = "{0}..{1}".format(hash_from, hash_to)
+        range_ = f"{hash_from}..{hash_to}"
         commits = self.git_repo.repo.iter_commits(range_)
         if not commits:
             return []

--- a/git_wrapper/remote.py
+++ b/git_wrapper/remote.py
@@ -57,21 +57,15 @@ class GitRemote(object):
         try:
             remote = self.git_repo.repo.remote(remote)
         except ValueError:
-            msg = "Remote {remote} does not exist on repo {repo}".format(
-                remote=remote,
-                repo=self.git_repo.repo.working_dir
-            )
+            repo = self.git_repo.repo.working_dir
+            msg = f"Remote {remote} does not exist on repo {repo}"
             raise exceptions.ReferenceNotFoundException(msg)
 
         try:
             remote.fetch()
         except git.GitCommandError as ex:
-            msg = (
-                "Could not fetch remote {remote} ({url}). "
-                "Error: {error}".format(remote=remote.name,
-                                        url=remote.url,
-                                        error=ex)
-            )
+            msg = (f"Could not fetch remote {remote.name} ({remote.url}). "
+                   f"Error: {ex}")
             raise exceptions.RemoteException(msg) from ex
 
     def fetch_all(self):
@@ -91,5 +85,5 @@ class GitRemote(object):
                 errors.append(remote)
 
         if errors:
-            msg = "Error fetching these remotes: {0}".format(", ".join(errors))
+            msg = f"Error fetching these remotes: {', '.join(errors)}"
             raise exceptions.RemoteException(msg)

--- a/git_wrapper/repo.py
+++ b/git_wrapper/repo.py
@@ -98,7 +98,7 @@ class GitRepo(object):
                                                  clone_to,
                                                  bare=bare)
         except git.GitCommandError as ex:
-            msg = "Error cloning repository {repo}".format(repo=clone_from)
+            msg = f"Error cloning repository {clone_from}"
             raise exceptions.RepoCreationException(msg) from ex
 
         return GitRepo(repo=repo)
@@ -118,7 +118,8 @@ class GitRepo(object):
         self.logger.debug("Remotes for %s: %s", local_path, ' '.join(list(remotes)))
 
         if len(remotes) == 0:
-            msg = "No remotes found for repo {repo}, cannot reclone. Aborting deletion.".format(repo=local_path)
+            msg = (f"No remotes found for repo {local_path}, cannot reclone. "
+                   "Aborting deletion.")
             raise exceptions.RepoCreationException(msg)
 
         # Select a remote for the clone, 'origin' by default
@@ -144,7 +145,7 @@ class GitRepo(object):
                     self.logger.debug("Adding remote %s", name)
                     r = self.repo.create_remote(name, url)
                 except git.GitCommandError as ex:
-                    msg = "Issue with recreating remote {remote}. Error: {error}".format(remote=name, error=ex)
+                    msg = f"Issue with recreating remote {name}. Error: {ex}"
                     raise exceptions.RemoteException(msg) from ex
 
     @property

--- a/git_wrapper/tag.py
+++ b/git_wrapper/tag.py
@@ -28,9 +28,7 @@ class GitTag(object):
         try:
             self.git_repo.repo.create_tag(name, reference)
         except git.GitCommandError as ex:
-            msg = "Error creating tag {name} on {ref}. Error: {error}".format(
-                name=name, ref=reference, error=ex
-            )
+            msg = f"Error creating tag {name} on {reference}. Error: {ex}"
             raise exceptions.TaggingException(msg) from ex
 
     @reference_exists('name')
@@ -42,9 +40,7 @@ class GitTag(object):
         try:
             self.git_repo.git.tag("-d", name)
         except git.GitCommandError as ex:
-            msg = "Error deleting tag {name}. Error: {error}".format(
-                name=name, error=ex
-            )
+            msg = f"Error deleting tag {name}. Error: {ex}"
             raise exceptions.TaggingException(msg) from ex
 
     @reference_exists('name')
@@ -56,13 +52,11 @@ class GitTag(object):
            :param bool dry_run: Whether to run the commands in dry-run mode
         """
         if remote not in self.git_repo.remote.names():
-            msg = "No remote named {0}".format(remote)
+            msg = f"No remote named {remote}"
             raise exceptions.ReferenceNotFoundException(msg)
 
-        msg = (
-            "Error pushing tag {name} (dry-run: {dry_run}) to remote "
-            "{remote}.".format(name=name, remote=remote, dry_run=dry_run)
-        )
+        msg = (f"Error pushing tag {name} (dry-run: {dry_run}) to remote "
+               f"{remote}.")
 
         try:
             if dry_run:
@@ -78,7 +72,7 @@ class GitTag(object):
             tags_list = [x.name for x in self.git_repo.repo.tags]
         except git.GitCommandError as ex:
             repo_path = self.git_repo.repo.working_dir
-            msg = "Error listing tags for {repo}. Error: {error}".format(error=ex, repo=repo_path)
+            msg = f"Error listing tags for {repo_path}. Error: {ex}"
             raise exceptions.TaggingException(msg) from ex
 
         return tags_list

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,12 +38,12 @@ def fake_commits(count=3):
     commits = []
     for i in range(0, count):
         author = Author(name="Test Author", email="testauthor@example.com")
-        msg = "This is a commit message (#{0})\nWith some details.".format(i)
+        msg = f"This is a commit message (#{i})\nWith some details."
 
         commit = Commit(
-            hexsha="00{0}0000000000000000".format(i),
+            hexsha=f"00{i}0000000000000000",
             message=msg,
-            summary="This is a commit message (#{0})".format(i),
+            summary=f"This is a commit message (#{i})",
             author=author,
             authored_datetime=datetime(2018, 12, 5, 10, 36, 19)
         )


### PR DESCRIPTION
The f-string format is more stylistically python 3 than the format
method, and subjectively, easier to read.  This patch switches all
uses of .format to use f-strings to provide a consistent base
going forward.

Signed-off-by: Jason Guiditta <jguiditt@redhat.com>