### PR TITLE
Limit to run only on master.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,7 @@ name: Upload Package to PyPI and TestPyPI
 
 on:
   push:
+    branches: [ master ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This will prevent things like seeing a failure every time you
push to your own fork to do a pull request.

Signed-off-by: Jason Guiditta <jguiditt@redhat.com>