### PR TITLE
Fixes for publish job.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,8 @@ name: Upload Package to PyPI and TestPyPI
 on:
   push:
     branches: [ master ]
+    tags:
+      - '*'
   workflow_dispatch:
 
 jobs:

--- a/Pipfile
+++ b/Pipfile
@@ -7,5 +7,5 @@ name = "pypi"
 git-wrapper = {path = ".", editable = true}
 
 [dev-packages]
-git-wrapper = {path = ".", extras = ["test","docs","dist"], editable = true}
+git-wrapper = {path = ".", extras = ["devbase","test","docs","dist"], editable = true}
 

--- a/dist-requirements.txt
+++ b/dist-requirements.txt
@@ -1,2 +1,2 @@
 -i https://pypi.python.org/simple
--e .[dist]
+-e .[devbase,dist]

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,8 @@ install_requires =
     wrapt
 
 [options.extras_require]
+devbase =
+    tox
 test =
     flake8
     mock>=2.0.0
@@ -38,7 +40,6 @@ test =
     pytest-cov
     pytest-datadir
     pytest-runner
-    tox
 
 docs =
     sphinx==4.1.2

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,2 @@
 -i https://pypi.python.org/simple
--e .[test]
+-e .[devbase,test]

--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,8 @@ commands =
     /usr/bin/podman run git_wrapper_integration_tests /bin/sh -c "pytest -k integration_tests integration_tests"  # Ensure we only run the integration tests
 
 [testenv:build]
+passenv =
+    SCM_NO_LOCAL_SCHEME
 allowlist_externals = /bin/bash
 commands_pre =
     /bin/bash tooling/build_changelog


### PR DESCRIPTION
This patch fixes a number of minor issues that currently prevent
the publish job from fully working as expected:

* Split out tox dep so all ci jobs get it automatically. By putting it
  in a different section, we can depend on tox for both publish and test
  jobs.
* Pass environment variable to tox. We were not passing the environment
  variable SCM_NO_LOCAL_SCHEME, which tells setuptools_scm not to
  include the githash in the build numbering.  If it is included, you
  cannot upload to pypi.

Signed-off-by: Jason Guiditta <jguiditt@redhat.com>