### PR TITLE
Added Prune Functionality To Fetch

### DIFF
--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -26,6 +26,10 @@ def repo_root():
     repo.heads.master.checkout()
     repo.head.reset(origin.refs.master, index=True, working_tree=True)
 
+    for t in repo.tags:
+        if "test" in t.name:
+            repo.git.tag("--delete", t.name)
+
     # Remove extra local branches
     for b in repo.branches:
         if b.name != 'master':

--- a/integration_tests/test_remote.py
+++ b/integration_tests/test_remote.py
@@ -1,0 +1,90 @@
+from git_wrapper.repo import GitRepo
+
+
+def test_prune_tags(repo_root, clone_repo_root):
+    repo = GitRepo(repo_root)
+    cloned_repo = GitRepo.clone(f"file://{repo_root}", clone_repo_root)
+
+    cloned_repo.tag.create("test_tag", "master")
+    assert "test_tag" in cloned_repo.tag.names()
+
+    cloned_repo.tag.push("test_tag", "origin")
+    assert "test_tag" in repo.tag.names()
+
+    cloned_repo.git.push("origin", "--delete", "test_tag")
+    assert "test_tag" not in repo.tag.names()
+    assert "test_tag" in cloned_repo.tag.names()
+    cloned_repo.remote.fetch("origin", prune=True, prune_tags=True)
+    assert "test_tag" not in cloned_repo.tag.names()
+
+
+def test_no_prune(repo_root, clone_repo_root):
+    repo = GitRepo(repo_root)
+    cloned_repo = GitRepo.clone(f"file://{repo_root}", clone_repo_root)
+
+    cloned_repo.tag.create("test_tag", "master")
+    assert "test_tag" in cloned_repo.tag.names()
+
+    cloned_repo.tag.push("test_tag", "origin")
+    assert "test_tag" in repo.tag.names()
+
+    repo.tag.delete("test_tag")
+    assert "test_tag" not in repo.tag.names()
+
+    cloned_repo.remote.fetch("origin")
+    assert "test_tag" in cloned_repo.tag.names()
+
+
+def test_prune_branches(repo_root, clone_repo_root):
+    repo = GitRepo(repo_root)
+    cloned_repo = GitRepo.clone(f"file://{repo_root}", clone_repo_root)
+
+    cloned_repo.branch.create("test_branch", "master")
+    cloned_repo.tag.create("testing_tag", "master")
+    assert "test_branch" in [b.name for b in cloned_repo.repo.branches]
+    assert "testing_tag" in cloned_repo.tag.names()
+
+    # throughout the test, we'll make sure we never delete test_tag in the cloned repo
+
+    cloned_repo.git.push("origin", "test_branch")
+    cloned_repo.git.push("origin", "testing_tag")
+    assert "test_branch" in [b.name for b in repo.repo.branches]
+    assert "origin/test_branch" in cloned_repo.repo.references
+
+    repo.git.branch("-D", "test_branch")
+    repo.tag.delete("testing_tag")
+    assert "test_branch" not in [b.name for b in repo.repo.branches]
+    assert "testing_tag" not in repo.tag.names()
+    assert "origin/test_branch" in cloned_repo.repo.references
+
+    assert "testing_tag" in cloned_repo.tag.names()
+    cloned_repo.remote.fetch("origin", prune=True)
+    assert "origin/test_branch" not in cloned_repo.repo.references
+    assert "testing_tag" in cloned_repo.tag.names()
+
+
+def test_prune_both(repo_root, clone_repo_root):
+    repo = GitRepo(repo_root)
+    cloned_repo = GitRepo.clone(f"file://{repo_root}", clone_repo_root)
+
+    cloned_repo.branch.create("test_branch", "master")
+    cloned_repo.tag.create("testing_tag", "master")
+    assert "test_branch" in [b.name for b in cloned_repo.repo.branches]
+    assert "testing_tag" in cloned_repo.tag.names()
+
+    cloned_repo.git.push("origin", "test_branch")
+    cloned_repo.git.push("origin", "testing_tag")
+    assert "test_branch" in [b.name for b in repo.repo.branches]
+    assert "testing_tag" in repo.tag.names()
+    assert "origin/test_branch" in cloned_repo.repo.references
+
+    repo.git.branch("-D", "test_branch")
+    repo.tag.delete("testing_tag")
+    assert "test_branch" not in [b.name for b in repo.repo.branches]
+    assert "testing_tag" not in repo.tag.names()
+    assert "origin/test_branch" in cloned_repo.repo.references
+    assert "testing_tag" in cloned_repo.tag.names()
+
+    cloned_repo.remote.fetch("origin", prune=True, prune_tags=True)
+    assert "origin/test_branch" not in cloned_repo.repo.references
+    assert "testing_tag" not in cloned_repo.tag.names()

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -101,8 +101,67 @@ def test_fetch(mock_repo):
 
     repo = GitRepo(repo=mock_repo)
     repo.remote.fetch()
-    assert mock_repo.remote.called is True
-    assert mock_remote.fetch.called is True
+
+    mock_repo.remote.assert_called()
+    mock_remote.fetch.assert_called()
+    mock_remote.fetch.assert_called_with(prune=False, prune_tags=False)
+
+
+def test_fetch_prune(mock_repo):
+    """
+    GIVEN GitRepo is initialized with a path and repo
+    WHEN remote.fetch is called
+    AND prune is True
+    THEN repo.remote is called
+    AND fetch is called with prune
+    """
+    mock_remote = Mock()
+    mock_repo.remote.return_value = mock_remote
+
+    repo = GitRepo(repo=mock_repo)
+    repo.remote.fetch(prune=True)
+
+    mock_repo.remote.assert_called()
+    mock_remote.fetch.assert_called()
+    mock_remote.fetch.assert_called_with(prune=True, prune_tags=False)
+
+
+def test_fetch_prune_tags(mock_repo):
+    """
+    GIVEN GitRepo is initialized with a path and repo
+    WHEN remote.fetch is called
+    AND prune and prune_tags are True
+    THEN repo.remote is called
+    AND fetch is called with prune and prune_tags
+    """
+    mock_remote = Mock()
+    mock_repo.remote.return_value = mock_remote
+
+    repo = GitRepo(repo=mock_repo)
+    repo.remote.fetch(prune=True, prune_tags=True)
+
+    mock_repo.remote.assert_called()
+    mock_remote.fetch.assert_called()
+    mock_remote.fetch.assert_called_with(prune=True, prune_tags=True)
+
+
+def test_fetch_no_prune(mock_repo):
+    """
+    GIVEN GitRepo is initialized with a path and repo
+    WHEN remote.fetch is called
+    AND prune_tags is True but prune is False
+    THEN repo.remote is called
+    AND fetch is called without prune and prune_tags
+    """
+    mock_remote = Mock()
+    mock_repo.remote.return_value = mock_remote
+
+    repo = GitRepo(repo=mock_repo)
+    repo.remote.fetch(prune=False, prune_tags=True)
+
+    mock_repo.remote.assert_called()
+    mock_remote.fetch.assert_called()
+    mock_remote.fetch.assert_called_with()
 
 
 def test_fetch_remote_doesnt_exist(mock_repo):
@@ -151,8 +210,55 @@ def test_fetch_all(mock_repo):
     repo.remote.names = Mock(return_value=["origin", "otherremote"])
 
     repo.remote.fetch_all()
-    assert mock_remoteA.fetch.called is True
-    assert mock_remoteB.fetch.called is True
+
+    mock_remoteA.fetch.assert_called()
+    mock_remoteB.fetch.assert_called()
+
+
+def test_fetch_all_prune(mock_repo):
+    """
+    GIVEN GitRepo is initialized with a path and repo
+    WHEN remote.fetch_all is called
+    AND there are 2 remotes
+    AND prune is True
+    THEN fetch is called twice with prune
+    """
+    mock_remoteA, mock_remoteB = Mock(), Mock()
+    mock_remotes = {"origin": mock_remoteA, "otherremote": mock_remoteB}
+    mock_repo.remote = lambda r: mock_remotes[r]
+
+    repo = GitRepo(repo=mock_repo)
+    repo.remote.names = Mock(return_value=["origin", "otherremote"])
+
+    repo.remote.fetch_all(prune=True)
+
+    mock_remoteA.fetch.assert_called()
+    mock_remoteB.fetch.assert_called()
+    mock_remoteA.fetch.assert_called_with(prune=True, prune_tags=False)
+    mock_remoteB.fetch.assert_called_with(prune=True, prune_tags=False)
+
+
+def test_fetch_all_prune_tags(mock_repo):
+    """
+    GIVEN GitRepo is initialized with a path and repo
+    WHEN remote.fetch_all is called
+    AND there are 2 remotes
+    AND prune and prune_tags are True
+    THEN fetch is called twice with prune and prune_tags
+    """
+    mock_remoteA, mock_remoteB = Mock(), Mock()
+    mock_remotes = {"origin": mock_remoteA, "otherremote": mock_remoteB}
+    mock_repo.remote = lambda r: mock_remotes[r]
+
+    repo = GitRepo(repo=mock_repo)
+    repo.remote.names = Mock(return_value=["origin", "otherremote"])
+
+    repo.remote.fetch_all(prune=True, prune_tags=True)
+
+    mock_remoteA.fetch.assert_called()
+    mock_remoteB.fetch.assert_called()
+    mock_remoteA.fetch.assert_called_with(prune=True, prune_tags=True)
+    mock_remoteB.fetch.assert_called_with(prune=True, prune_tags=True)
 
 
 def test_fetch_all_with_errors(mock_repo):
@@ -177,6 +283,7 @@ def test_fetch_all_with_errors(mock_repo):
         repo.remote.fetch_all()
 
     assert 'origin' in str(exc_info.value)
-    assert mock_remoteA.fetch.called is True
-    assert mock_remoteB.fetch.called is True
-    assert mock_remoteC.fetch.called is True
+
+    mock_remoteA.fetch.assert_called()
+    mock_remoteB.fetch.assert_called()
+    mock_remoteC.fetch.assert_called()


### PR DESCRIPTION
Prune related tags were added to the fetch
functions in order to give more functionality
to consumers. This will allow for branches and tags
to be easily pruned simply by calling the fetch function
with the appropriate boolean tags.