### PR TITLE
Update github action versions.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,13 +34,13 @@ jobs:
       run:  tox -ebuild
     - name: Publish to Test PyPI
       if: startsWith(github.ref, 'refs/tags/') != true
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.TEST_PYPI_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
       with:
         user: __token__

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,11 +9,11 @@ jobs:
       runs-on: ubuntu-latest
       strategy:
         matrix:
-          python: [3.6, 3.7, 3.8, 3.9]
+          python: ['3.7', '3.8', '3.9', '3.10', '3.11']
       steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
         - name: Setup Python
-          uses: actions/setup-python@v2
+          uses: actions/setup-python@v4
           with:
             python-version: ${{ matrix.python }}
         - name: Install Tox and any other packages
@@ -26,11 +26,11 @@ jobs:
     flake8:
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
         - name: Setup Python
-          uses: actions/setup-python@v2
+          uses: actions/setup-python@v4
           with:
-            python-version: 3.9
+            python-version: 3.11
         - name: Install Tox and any other packages
           run: |
             python -m pip install --upgrade pip
@@ -40,11 +40,11 @@ jobs:
     integration:
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
         - name: Setup Python
-          uses: actions/setup-python@v2
+          uses: actions/setup-python@v4
           with:
-            python-version: 3.9
+            python-version: 3.11
         - name: Install Tox and any other packages
           run: |
             python -m pip install --upgrade pip
@@ -54,13 +54,13 @@ jobs:
     twine:
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
           with:
             fetch-depth: 0
         - name: Setup Python
-          uses: actions/setup-python@v2
+          uses: actions/setup-python@v4
           with:
-            python-version: 3.9
+            python-version: 3.11
         - name: Install Tox and any other packages
           run: |
             python -m pip install --upgrade pip

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38,39}
+    py{37,38,39,310,311}
     flake8
 
 [testenv]
@@ -19,6 +19,9 @@ commands =
     flake8 --ignore=E501 setup.py docs git_wrapper tests integration_tests
 
 [testenv:integration]
+allowlist_externals =
+    /usr/bin/find
+    /usr/bin/sudo
 commands =
     /usr/bin/find . -name '*.pyc' -delete  # Avoid issues with pytests conf file discovery
     /usr/bin/sudo docker build -t git_wrapper_integration_tests .


### PR DESCRIPTION
For publish, master is no longer recommended or maintained, so point the action at a release:
https://github.com/pypa/gh-action-pypi-publish#-master-branch-sunset-

Release versions of checkout and python actions also needed to be updated due to github changing the node they run on: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Update supported versions of python, as we only went up to python 3.9, and 3.6 is now EOL:
https://devguide.python.org/versions/

Signed-off-by: Jason Guiditta <jguiditt@redhat.com>